### PR TITLE
Fixed bug introduced in the Refactored GUI commit

### DIFF
--- a/src/ui/components/StatPanel.java
+++ b/src/ui/components/StatPanel.java
@@ -105,7 +105,7 @@ public class StatPanel extends JPanel implements IUpdatablePanel {
     public void update(LocalTime peak) {
         peak();
         avg();
-        currentValue.setText(parameter + suffix);
+        currentValue.setText(stats.GetCurrent(parameter) + suffix);
         currentValue.setToolTipText("Peak: " + peakValue + suffix + ", Peaked at: " + peak.format(timeFormatter) +
                 ", Average: " + avgValue + suffix);
     }


### PR DESCRIPTION
https://github.com/ValenceElectron/gmon_parser/commit/a1972188024a4f6429688dbded17e91b85d44eff introduced a bug where it would display "TemperatureC", "Fan Speed%", or "Time Elapsed" instead of the actual values.